### PR TITLE
CPack binary archive generation

### DIFF
--- a/ci/x86_64-w64-mingw32.cmake
+++ b/ci/x86_64-w64-mingw32.cmake
@@ -1,15 +1,15 @@
 # the name of the target operating system
 set(CMAKE_SYSTEM_NAME Windows)
 
-set(PREFIX x86_64-w64-mingw32)
+set(MINGW_PREFIX x86_64-w64-mingw32 CACHE STRING "" FORCE)
 
 # which compilers to use for C and C++
-set(CMAKE_C_COMPILER ${PREFIX}-gcc)
-set(CMAKE_CXX_COMPILER ${PREFIX}-g++)
-set(CMAKE_RC_COMPILER ${PREFIX}-windres)
+set(CMAKE_C_COMPILER ${MINGW_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${MINGW_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${MINGW_PREFIX}-windres)
 
 # here is the target environment located
-set(CMAKE_FIND_ROOT_PATH /usr/${PREFIX})
+set(CMAKE_FIND_ROOT_PATH /usr/${MINGW_PREFIX})
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search
@@ -22,13 +22,13 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(bundled_libs_dir ${PROJECT_SOURCE_DIR}/src/bundled-libs)
 
 set(ZLIB_INCLUDE_DIR ${bundled_libs_dir}/include)
-set(ZLIB_LIBRARY ${bundled_libs_dir}/${PREFIX}/lib/zlib1.dll)
+set(ZLIB_LIBRARY ${bundled_libs_dir}/${MINGW_PREFIX}/lib/zlib1.dll)
 
 set(SDL2_INCLUDE_DIR ${bundled_libs_dir}/include CACHE PATH "" FORCE)
-set(SDL2_LIBRARY ${bundled_libs_dir}/${PREFIX}/lib/SDL2.dll CACHE PATH "" FORCE)
+set(SDL2_LIBRARY ${bundled_libs_dir}/${MINGW_PREFIX}/lib/SDL2.dll CACHE PATH "" FORCE)
 
 set(SDL2_IMAGE_INCLUDE_DIR ${bundled_libs_dir}/include CACHE PATH "" FORCE)
-set(SDL2_IMAGE_LIBRARY ${bundled_libs_dir}/${PREFIX}/lib/SDL2_image.dll CACHE PATH "" FORCE)
+set(SDL2_IMAGE_LIBRARY ${bundled_libs_dir}/${MINGW_PREFIX}/lib/SDL2_image.dll CACHE PATH "" FORCE)
 
 set(SDL2_MIXER_INCLUDE_DIR ${bundled_libs_dir}/include CACHE PATH "" FORCE)
-set(SDL2_MIXER_LIBRARY ${bundled_libs_dir}/${PREFIX}/lib/SDL2_mixer.dll CACHE PATH "" FORCE)
+set(SDL2_MIXER_LIBRARY ${bundled_libs_dir}/${MINGW_PREFIX}/lib/SDL2_mixer.dll CACHE PATH "" FORCE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,3 +153,13 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         DESTINATION bin
     )
 endif()
+
+
+# general CPack configuration
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_general.cmake)
+
+# add support for release archive generation
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_archive.cmake)
+
+# must be the last instruction
+include(CPack)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,3 +128,28 @@ install(
     DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/icons
     DESTINATION share
 )
+
+# install bundled binaries
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    if(MINGW_PLATFORM)
+        message(STATUS "Building with MinGW cross toolchain, prefix: ${MINGW_PREFIX}")
+        set(WINDOWS_LIBRARY_PREFIX ${MINGW_PREFIX})
+    else()
+        # we only support x86_64/i686 architectures, so we can "guess" the prefixes
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            set(WINDOWS_LIBRARY_PREFIX x86_64-w64-mingw32)
+        elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+            set(WINDOWS_LIBRARY_PREFIX i686-w64-mingw32)
+        else()
+            message(FATAL_ERROR "Unknown platform, please re-run with -DWINDOWS_LIBRARY_PREFIX=...")
+        endif()
+        message(STATUS "Building for Windows without cross toolchain, guessing prefix ${WINDOWS_LIBRARY_PREFIX}")
+    endif()
+
+    message(STATUS "Installing Windows binaries into bin directory")
+    file(GLOB BUNDLED_LIBS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/bundled-libs/${WINDOWS_LIBRARY_PREFIX}/lib/*)
+    install(
+        FILES ${BUNDLED_LIBS_FILES}
+        DESTINATION bin
+    )
+endif()

--- a/src/cmake/cpack_archive.cmake
+++ b/src/cmake/cpack_archive.cmake
@@ -1,0 +1,4 @@
+# release archive option
+
+# make sure all components (if there are any) end up in the same tarball
+set(CPACK_ARCHIVE_COMPONENT_INSTALL OFF)

--- a/src/cmake/cpack_general.cmake
+++ b/src/cmake/cpack_general.cmake
@@ -1,0 +1,26 @@
+# general CPack options
+
+#set(PROJECT_VERSION ${APPIMAGELAUNCHER_VERSION})
+
+# package them all in a single package, otherwise cpack would generate one package per component by default
+# https://cmake.org/cmake/help/v3.0/module/CPackComponent.html#variable:CPACK_COMPONENTS_GROUPING
+set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
+
+# global options
+set(CPACK_PACKAGE_CONTACT "Red Eclipse Legacy Team")
+set(CPACK_PACKAGE_HOMEPAGE "https://github.com/redeclipse-legacy")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.md")
+#set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
+
+# we gather our version number from git
+execute_process(
+    COMMAND git describe --tags HEAD
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE _CPACK_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# CMake composes file names using a <package_name>-<package_version>-<platform>.<ext> scheme
+set(CPACK_PACKAGE_NAME red-eclipse-legacy)
+set(CPACK_PACKAGE_VERSION ${_CPACK_VERSION})
+


### PR DESCRIPTION
This PR introduces rudimentary support for generating binary archives with CPack. The binary archives use the same new FHS-oriented layout for storing binaries and datas.

It is primarily meant for generating zip balls for Windows. Therefore this PR further adds install configs for the bundled libraries (SDL2, zlib etc.).

It is yet to be tested on a real Windows system.

We have tested different archive types (CPack generators `7Z`, `ZIP`, `TGZ`). While `7Z` and `TGZ` produce archives with a size of ca. 850 MiB, `7Z` reduces the size by around 20 MiB, but takes significantly longer and requires special software for extraction. Therefore it is recommended to just use `ZIP`.